### PR TITLE
fix: For CVE-2021-44228

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ COPY config /elasticsearch/config
 COPY run.sh /
 
 # Set environment variables defaults
-ENV ES_JAVA_OPTS "-Xms512m -Xmx512m"
+ENV ES_JAVA_OPTS "-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
 ENV CLUSTER_NAME elasticsearch-default
 ENV NODE_MASTER true
 ENV NODE_DATA true


### PR DESCRIPTION
This will protect against the log4Shell vuln. as a stop gap before upgrading the ES version